### PR TITLE
Feature: Select download resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ mediakit <video_url> [<output_path>]
 ```
 
 - **video_url**: the URL of the video to download (e.g. http://www.youtube.com/watch?v=...).
+
     > As URL's may have special characters, it is recommended that you **wrap the URL in double quotes** ("") to ensure that it will be recognized properly.
+
 - **output_path**: optional destination folder to where to save the downloads. If not provided, this will default to the current directory.
+
     > You can also provide a custom name for the downloaded file. To do that, include it in the output path (e.g. path/to/folder/video.mp4).
 
 After running this command, an interactive CLI will guide you through the download process.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ mediakit <video_url> [<output_path>]
 
 After running this command, an interactive CLI will guide you through the download process.
 
-
 ### Examples of use:
 
 Download to the current directory
@@ -66,6 +65,32 @@ Download to **~/Videos** with name **song.mp4**
 ```bash
 mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI" ~/Videos/song.mp4
 ```
+
+### Selecting specific download formats
+
+By default, MediaKit will download the video with the highest available resolution. However, you can select specific download formats with the flag `--formats` (or its shorthand `-f`), followed by one or more desired formats:
+
+```bash
+mediakit <video_url> [<output_path>] [-f | --formats]
+```
+
+> If a resolution is not available for the video, the download will fall back to the closest available resolution lower than the one specified.
+
+**Examples of use:**
+- Download video with resolution of **1080p**
+  ```bash
+  mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI" -f 1080p
+  ```
+
+- Download video with resolutions of **1080p** and **720p**
+  ```bash
+  mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI" -f 1080p 720p
+  ```
+
+- Download video with **highest resolution available** (same result as not using the flag `-f`)
+  ```bash
+  mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI" -f max
+  ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,14 @@
 ## Features
 
 - Quickly download YouTube videos with a single command on your terminal
+- Select specific download formats if you want to
 
 ## Installation
 
-To install MediaKit, you'll need to have [Python 3](https://www.python.org/downloads/) (>= 3.6) and [pip](https://pip.pypa.io/en/stable/installing/) already installed on your computer. With those packages available, run:
+To install MediaKit, you'll need to have [Python 3.6+](https://www.python.org/downloads/) and [pip](https://pip.pypa.io/en/stable/installing/) installed on your computer. Then, run:
 
 ```bash
 pip install mediakit
-```
-
-or
-
-```bash
-pip3 install mediakit
 ```
 
 ## How to use
@@ -49,26 +44,25 @@ mediakit <video_url> [<output_path>]
 
 After running this command, an interactive CLI will guide you through the download process.
 
-### Examples of use:
+**Examples of use:**
+  - Download to the current directory
+    ```bash
+    mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI"
+    ```
 
-Download to the current directory
-```bash
-mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI"
-```
+  - Download to **~/Videos**
+    ```bash
+    mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI" ~/Videos
+    ```
 
-Download to **~/Videos**
-```bash
-mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI" ~/Videos
-```
-
-Download to **~/Videos** with name **song.mp4**
-```bash
-mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI" ~/Videos/song.mp4
-```
+  - Download to **~/Videos** with name **song.mp4**
+    ```bash
+    mediakit "https://www.youtube.com/watch?v=m7AFEULF9LI" ~/Videos/song.mp4
+    ```
 
 ### Selecting specific download formats
 
-By default, MediaKit will download the video with the highest available resolution. However, you can select specific download formats with the flag `--formats` (or its shorthand `-f`), followed by one or more desired formats:
+By default, MediaKit will download the specified video with the highest available resolution. However, you can select specific download formats with the flag `--formats` (or its shorthand `-f`), followed by one or more desired formats:
 
 ```bash
 mediakit <video_url> [<output_path>] [-f | --formats]

--- a/mediakit/actions/download.py
+++ b/mediakit/actions/download.py
@@ -51,10 +51,15 @@ def download():
         download_cli.show_success_message()
 
     except exceptions.FFMPEGNotAvailable as exception:
-        exceptions.show_exception_message(exception)
+        download_cli.remove_loading_label()
+        exception.show_message()
     except PytubeRegexMatchError:
-        exceptions.show_exception_message(exceptions.InvalidVideoURLError())
+        download_cli.remove_loading_label()
+        exceptions.InvalidVideoURLError().show_message()
+    except KeyboardInterrupt:
+        pass
     except Exception:
-        exceptions.show_exception_message(exceptions.UnspecifiedError())
+        download_cli.remove_loading_label()
+        exceptions.UnspecifiedError().show_message()
     finally:
         download_cli.terminate()

--- a/mediakit/actions/download.py
+++ b/mediakit/actions/download.py
@@ -22,6 +22,8 @@ def download():
     if filename:
         output_path = path.dirname(output_path)
 
+    formats = arguments.formats
+
     download_cli = DownloadCLI()
     download_cli.start()
 
@@ -30,7 +32,12 @@ def download():
             raise exceptions.FFMPEGNotAvailable()
 
         video = YouTube(video_url)
-        download_cli.register_download_info(video, output_path, filename)
+        download_cli.register_download_info(
+            video,
+            output_path,
+            filename,
+            formats
+        )
         download_cli.show_video_heading()
         download_cli.show_download_summary()
 

--- a/mediakit/actions/download.py
+++ b/mediakit/actions/download.py
@@ -53,6 +53,8 @@ def download():
     except exceptions.FFMPEGNotAvailable as exception:
         download_cli.remove_loading_label()
         exception.show_message()
+    except exceptions.NoAvailableSpecifiedFormats as exception:
+        exception.show_message()
     except PytubeRegexMatchError:
         download_cli.remove_loading_label()
         exceptions.InvalidVideoURLError().show_message()

--- a/mediakit/constants.py
+++ b/mediakit/constants.py
@@ -1,3 +1,14 @@
 from .utils.ffmpeg import get_ffmpeg_binary
 
 FFMPEG_BINARY = get_ffmpeg_binary()
+
+YOUTUBE_VIDEO_RESOLUTIONS = {
+    '2160p': { 'next': '1440p' },
+    '1440p': { 'next': '1080p' },
+    '1080p': { 'next': '720p' },
+    '720p': { 'next': '480p' },
+    '480p': { 'next': '360p' },
+    '360p': { 'next': '240p' },
+    '240p': { 'next': '144p' },
+    '144p': { 'next': None }
+}

--- a/mediakit/exceptions.py
+++ b/mediakit/exceptions.py
@@ -10,7 +10,7 @@ class MediaKitException(Exception):
 class CommandUnavailable(MediaKitException):
     def __init__(self, command):
         self.message = (
-            f"Command '{command}' is not available.\n"
+            f"Command '{command}' is not available.\n\n"
         )
         self.category = ContentCategories.ERROR
 
@@ -22,7 +22,7 @@ class FFMPEGNotAvailable(MediaKitException):
         self.message = (
             'FFmpeg is a required package for MediaKit, '
             "but it doesn't appear to be installed.\n"
-            'You can install FFmpeg at https://ffmpeg.org/download.html.\n'
+            'You can install FFmpeg at https://ffmpeg.org/download.html.\n\n'
         )
         self.category = ContentCategories.WARNING
 
@@ -32,7 +32,7 @@ class FFMPEGNotAvailable(MediaKitException):
 class InvalidVideoURLError(MediaKitException):
     def __init__(self):
         self.message = (
-            'Could not recognize the provided URL. Please, try again.\n'
+            'Could not recognize the provided URL. Please, try again.\n\n'
         )
         self.category = ContentCategories.ERROR
 
@@ -41,7 +41,7 @@ class InvalidVideoURLError(MediaKitException):
 
 class UnspecifiedError(MediaKitException):
     def __init__(self):
-        self.message = 'Something went wrong. :(\nPlease, try again.\n'
+        self.message = 'Something went wrong. :(\nPlease, try again.\n\n'
         self.category = ContentCategories.ERROR
 
         super().__init__(self.message)

--- a/mediakit/exceptions.py
+++ b/mediakit/exceptions.py
@@ -2,7 +2,8 @@ from mediakit.streams.screen import screen, ContentCategories
 
 
 class MediaKitException(Exception):
-    pass
+    def show_message(self):
+        screen.append_content(self.message, self.category)
 
 
 class CommandUnavailable(MediaKitException):
@@ -43,7 +44,3 @@ class UnspecifiedError(MediaKitException):
         self.category = ContentCategories.ERROR
 
         super().__init__(self.message)
-
-
-def show_exception_message(exception):
-    screen.append_content(exception.message, exception.category)

--- a/mediakit/exceptions.py
+++ b/mediakit/exceptions.py
@@ -1,4 +1,5 @@
 from mediakit.streams.screen import screen, ContentCategories
+from mediakit.streams.colors import colored, Colors
 
 
 class MediaKitException(Exception):
@@ -41,6 +42,25 @@ class InvalidVideoURLError(MediaKitException):
 class UnspecifiedError(MediaKitException):
     def __init__(self):
         self.message = 'Something went wrong. :(\nPlease, try again.\n'
+        self.category = ContentCategories.ERROR
+
+        super().__init__(self.message)
+
+
+class NoAvailableSpecifiedFormats(MediaKitException):
+    def __init__(self, available_formats):
+        self.message = (
+            'None of the specified formats were found.\n'
+            + 'Please, verify your entries and try again.\n\n'
+
+            + 'The formats available for this video are: '
+            + colored(
+                ' '.join(available_formats),
+                fore=Colors.fore.BLUE,
+                style=Colors.style.BRIGHT
+            )
+            + '\n\n'
+        )
         self.category = ContentCategories.ERROR
 
         super().__init__(self.message)

--- a/mediakit/media/download.py
+++ b/mediakit/media/download.py
@@ -19,16 +19,22 @@ class MediaResource:
         output_type,
         output_path=None,
         definition='max',
-        filename=''
+        filename='',
+        filename_suffix=''
     ):
         self.source = source
         self.output_type = output_type
         self.output_path = output_path
 
-        self.filename = get_safe_filename(
-            filename if filename
-            else f'{source.title}.mp4'
-        )
+        if filename:
+            filename_without_extension, extension = filename.split('.')
+            self.filename = get_safe_filename(
+                f'{filename_without_extension}{filename_suffix}.{extension}'
+            )
+        else:
+            self.filename = get_safe_filename(
+                f'{source.title}{filename_suffix}.mp4'
+            )
 
         if output_type == 'video/audio':
             self.video = self._get_video_stream(definition)

--- a/mediakit/streams/arguments.py
+++ b/mediakit/streams/arguments.py
@@ -32,6 +32,13 @@ def parse_download_arguments():
         default='./',
         help='Destination folder to where to save the downloads'
     )
+    parser.add_argument(
+        '-f',
+        '--formats',
+        nargs='*',
+        default=[],
+        help='Formats to download, separated by spaces (e.g. 1080p 720p 360p)'
+    )
 
     arguments = parser.parse_args()
 

--- a/mediakit/streams/cli.py
+++ b/mediakit/streams/cli.py
@@ -349,9 +349,20 @@ class DownloadCLI:
     ):
         label = download_status.title()
 
+        is_downloading_first_media_resource = (
+            self.downloading_media_resource
+            is self.media_resources_to_download[0]
+        )
+
+        should_include_starting_newline = (
+            is_downloading_first_media_resource
+            or (download_status != DownloadStatusCodes.DONE)
+        )
+
         heading = (
-            colored(
-                f'\n{status_character} {label} ',
+            ('\n' if should_include_starting_newline else '')
+            + colored(
+                f'{status_character} {label} ',
                 fore=status_color
             )
             + colored(

--- a/mediakit/streams/cli.py
+++ b/mediakit/streams/cli.py
@@ -287,9 +287,19 @@ class DownloadCLI:
         return media_resources_to_download
 
     def _is_format_available(self, selected_format):
-        filtered_streams = self.video.streams.filter(resolution=selected_format)
+        if selected_format == 'max':
+            video_streams = self.video.streams.filter(mime_type='video/mp4')
 
-        return len(filtered_streams) > 0
+            return len(video_streams) > 0
+
+        video_streams_with_specified_resolution = (
+            self.video.streams.filter(
+                mime_type='video/mp4',
+                resolution=selected_format
+            )
+        )
+
+        return len(video_streams_with_specified_resolution) > 0
 
     def _create_download_progress(self, media_resource):
         self.downloading_media_resource = media_resource

--- a/mediakit/streams/cli.py
+++ b/mediakit/streams/cli.py
@@ -7,6 +7,7 @@ from mediakit.streams.screen import screen, ContentCategories
 from mediakit.streams.colors import colored, Colors
 from mediakit.media.download import MediaResource, DownloadStatusCodes
 from mediakit.utils.format import limit_text_length
+from mediakit import exceptions
 
 loading_dots = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 rotating_lines = ['|', '/', '-', '\\']
@@ -56,7 +57,7 @@ class DownloadCLI:
 
         self.short_video_title = self._format_video_title(26)
 
-        self._remove_loading_label()
+        self.remove_loading_label()
 
     def show_video_heading(self):
         formatted_video_length = self._format_video_length()
@@ -94,6 +95,9 @@ class DownloadCLI:
         screen.append_content(video_summary)
 
     def show_download_summary(self):
+        if self.were_all_formats_skipped():
+            raise exceptions.NoAvailableSpecifiedFormats(self.available_formats)
+
         if len(self.skipped_formats) > 0:
             self._show_skipped_formats_warning()
 
@@ -203,7 +207,7 @@ class DownloadCLI:
     def terminate(self):
         self.is_terminated = True
 
-    def _remove_loading_label(self):
+    def remove_loading_label(self):
         if self.loading_label is not None:
             screen.remove_content(self.loading_label)
 

--- a/mediakit/streams/screen.py
+++ b/mediakit/streams/screen.py
@@ -29,11 +29,19 @@ class Content:
         elif category == ContentCategories.USER_INPUT:
             self.category_label = colored('? ', fore=Colors.fore.BLUE)
 
-        self.inner_text = f'{self.category_label}{text}'
+        self.update_inner_text(text)
 
     def update_inner_text(self, new_text):
-        self.inner_text = f'{self.category_label}{new_text}'
+        new_text_stripped_of_leading_newlines = new_text.lstrip('\n')
+        number_of_leading_newlines = (
+            len(new_text) - len(new_text_stripped_of_leading_newlines)
+        )
 
+        self.inner_text = (
+            '\n' * number_of_leading_newlines
+            + self.category_label
+            + new_text_stripped_of_leading_newlines
+        )
 
 class Screen:
     def __init__(self):


### PR DESCRIPTION
**Adds:**
- Support to select specific download resolutions (e.g. 1080p and 720p) with the flag **`-f`** (or **`--formats`**)

   > Formats specified by the user are validated before downloading. If the format is not valid, a warning message is shown. If the format is in fact valid, but unavailable for the current video, the download will fall back to an available format with lower resolution. If no format is specified, MediaKit will download the video with the highest available resolution.
- Guide about how to use this feature to README.md

**Updates:**
- Wording and overall structure of `README.md`