### PR TITLE
Disable CLI colors when running in background

### DIFF
--- a/mediakit/globals.py
+++ b/mediakit/globals.py
@@ -1,7 +1,9 @@
+import sys
+
 class GlobalConfig:
     def __init__(self):
         self.answer_yes_to_all_questions = False
-        self.ui_colors_disabled = False
+        self.ui_colors_disabled = not sys.stdin.isatty()
 
 
 global_config = GlobalConfig()


### PR DESCRIPTION
**Changes:**
- CLI colors are now automatically disabled when it is detected that Mediakit is running in background