### PR TITLE
Feature: Download from batch file (`-b` / `--batch`)

### DIFF
--- a/mediakit/actions/download.py
+++ b/mediakit/actions/download.py
@@ -65,7 +65,7 @@ def download():
             if not global_config.answer_yes_to_all_questions:
                 confirmed = download_cli.ask_for_confirmation_to_download()
                 if not confirmed:
-                    return
+                    continue
 
             video.register_on_progress_callback(on_download_progress)
 

--- a/mediakit/actions/download.py
+++ b/mediakit/actions/download.py
@@ -5,7 +5,11 @@ from pytube.exceptions import RegexMatchError as PytubeRegexMatchError
 
 from mediakit.streams.arguments import command_args
 from mediakit.streams.cli import DownloadCLI
-from mediakit.utils.files import get_filename_from, read_video_urls_from
+from mediakit.utils.files import (
+    get_filename_from,
+    read_video_urls_from,
+    file_exists
+)
 from mediakit.constants import FFMPEG_BINARY
 from mediakit.globals import global_config
 from mediakit import exceptions
@@ -17,8 +21,13 @@ def download():
 
     arguments = command_args.parse_download_arguments()
 
-    if global_config.batch_file:
-        video_urls_to_download = read_video_urls_from(global_config.batch_file)
+    was_batch_file_provided = global_config.batch_file is not None
+    if was_batch_file_provided:
+        if file_exists(global_config.batch_file):
+            video_urls_to_download = read_video_urls_from(global_config.batch_file)
+        else:
+            exceptions.NoSuchFile(global_config.batch_file).show_message()
+            return
     else:
         video_urls_to_download = [arguments.video_url]
 

--- a/mediakit/actions/main.py
+++ b/mediakit/actions/main.py
@@ -13,11 +13,12 @@ def get_command_actions():
 
     if command_args.has_argument(GlobalArguments.help):
         actions.append(show_help_message)
-        return actions
     if command_args.has_argument(GlobalArguments.version):
         actions.append(show_current_version)
-        return actions
-    if command_args.has_video_url():
+    if (
+        command_args.has_video_url()
+        or command_args.has_argument(GlobalArguments.batch)
+    ):
         actions.append(download)
 
     if len(actions) == 0:

--- a/mediakit/exceptions.py
+++ b/mediakit/exceptions.py
@@ -92,3 +92,18 @@ class NoSuchFile(MediaKitException):
         self.category = ContentCategories.ERROR
 
         super().__init__(self.message)
+
+
+class NoVideoURLsInBatchFile(MediaKitException):
+    def __init__(self, batch_file):
+        self.message = (
+            '\nCould not find any valid video URLs in '
+            + colored(
+                batch_file,
+                fore=Colors.fore.MAGENTA
+            )
+            + '\nPlease check your entries and try again.\n\n'
+        )
+        self.category = ContentCategories.ERROR
+
+        super().__init__(self.message)

--- a/mediakit/exceptions.py
+++ b/mediakit/exceptions.py
@@ -77,3 +77,18 @@ class NoAvailableSpecifiedFormats(MediaKitException):
         self.category = ContentCategories.ERROR
 
         super().__init__(self.message)
+
+
+class NoSuchFile(MediaKitException):
+    def __init__(self, supposed_file):
+        self.message = (
+            '\nNo such file: '
+            + colored(
+                supposed_file,
+                fore=Colors.fore.MAGENTA
+            )
+            + '\n\n'
+        )
+        self.category = ContentCategories.ERROR
+
+        super().__init__(self.message)

--- a/mediakit/globals.py
+++ b/mediakit/globals.py
@@ -1,9 +1,11 @@
 import sys
 
+
 class GlobalConfig:
     def __init__(self):
         self.answer_yes_to_all_questions = False
         self.ui_colors_disabled = not sys.stdin.isatty()
+        self.batch_file = None
 
 
 global_config = GlobalConfig()

--- a/mediakit/streams/cli.py
+++ b/mediakit/streams/cli.py
@@ -702,6 +702,7 @@ class DownloadCLI:
 
     def clear_detailed_download_info_from_screen(self):
         if self.confirm_download_prompt_message:
+            screen.erase_prompt_entry(self.confirm_download_prompt_message)
             screen.remove_content(self.confirm_download_prompt_message)
         screen.remove_content(self.total_download_size_label)
         screen.remove_content(self.ready_to_download_label)

--- a/mediakit/streams/screen.py
+++ b/mediakit/streams/screen.py
@@ -140,7 +140,14 @@ class Screen:
             if valid_entry:
                 return entry, self.prompt_message
 
-            self._erase_prompt_entry()
+            self.erase_prompt_entry(self.prompt_message)
+
+    def erase_prompt_entry(self, prompt):
+        lines_occupied_by_entry = 2 # <entry>\n<empty line> -> 2 lines to clear
+        self.clear_lines(lines_occupied_by_entry)
+
+        self._clear_lines_starting_at(prompt)
+        self._render_contents_starting_at(prompt)
 
     def _render_content(self, content):
         print(content.inner_text, end='', file=sys.stderr)
@@ -163,13 +170,6 @@ class Screen:
     def _render_contents_starting_at(self, content):
         for i in range(content.index_on_screen, len(self.contents)):
             self._render_content(self.contents[i])
-
-    def _erase_prompt_entry(self):
-        lines_occupied_by_entry = 2 # <entry>\n<empty line> -> 2 lines to clear
-        self.clear_lines(lines_occupied_by_entry)
-
-        self._clear_lines_starting_at(self.prompt_message)
-        self._render_contents_starting_at(self.prompt_message)
 
     def _count_lines_occupied_by(self, text, current_console_width):
         lines = text.split('\n')

--- a/mediakit/streams/screen.py
+++ b/mediakit/streams/screen.py
@@ -138,7 +138,7 @@ class Screen:
             )
 
             if valid_entry:
-                return entry
+                return entry, self.prompt_message
 
             self._erase_prompt_entry()
 

--- a/mediakit/streams/screen.py
+++ b/mediakit/streams/screen.py
@@ -148,14 +148,15 @@ class Screen:
     def _clear_lines_starting_at(self, content):
         current_console_width = self.get_console_width()
 
-        lines_to_clear = 0
-        for i in range(content.index_on_screen, len(self.contents)):
-            content = self.contents[i]
+        texts_to_clear = map(
+            lambda content_to_clear: content_to_clear.inner_text,
+            self.contents[content.index_on_screen:]
+        )
 
-            lines_to_clear += self._count_lines_occupied_by(
-                content,
-                current_console_width
-            )
+        lines_to_clear = self._count_lines_occupied_by(
+            ''.join(texts_to_clear),
+            current_console_width
+        )
 
         self.clear_lines(lines_to_clear)
 
@@ -170,8 +171,8 @@ class Screen:
         self._clear_lines_starting_at(self.prompt_message)
         self._render_contents_starting_at(self.prompt_message)
 
-    def _count_lines_occupied_by(self, content, current_console_width):
-        lines = content.inner_text.split('\n')
+    def _count_lines_occupied_by(self, text, current_console_width):
+        lines = text.split('\n')
 
         lines_occupied = 0
         for i in range(len(lines)):

--- a/mediakit/utils/files.py
+++ b/mediakit/utils/files.py
@@ -2,6 +2,7 @@ from os import path
 import re
 
 from mediakit.utils.commands import run_command_in_background
+from mediakit.utils import regex
 
 
 def file_exists(file_path):
@@ -56,3 +57,16 @@ def increment_filename_if_exists(file_path):
             file_path_dirname,
             f'{filename_without_extension}({filename_number}).{extension}'
         )
+
+
+def read_video_urls_from(batch_file_path):
+    video_urls = []
+
+    with open(batch_file_path, 'r', encoding='utf-8') as batch_file:
+        for line in batch_file:
+            clear_line = line.strip()
+
+            if regex.is_video_url_like(clear_line):
+                video_urls.append(clear_line)
+
+    return video_urls


### PR DESCRIPTION
**Changes:**
- Added support to read video URLs from a text file (**batch**). To use this feature, you should create a text file containing one video URL per line, and pass that file in the flag **`-b`**, or **`--batch`** (e.g. `mediakit -b videos.txt`)