### PR TITLE
Fix: Do not re-raise unspecified exceptions

### DIFF
--- a/mediakit/actions/download.py
+++ b/mediakit/actions/download.py
@@ -106,7 +106,6 @@ def download():
         except Exception:
             download_cli.remove_loading_label()
             exceptions.UnspecifiedError().show_message()
-            raise
         finally:
             if is_last_video:
                 download_cli.terminate()


### PR DESCRIPTION
**Changes:**
- Minor fix: removed an extra `raise` keyword, which used to re-raise unspecified exceptions